### PR TITLE
edited checks for absolute/portable paths

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -285,7 +285,7 @@ attr(has_no_nested_proj_root, "req_compilation") <- FALSE
 #' @export
 has_no_absolute_paths <- function(path = ".", ...) {
   check_is_dir(path)
-  paths <- log_report(path) %>%
+  paths <- log_report(path_log(path)) %>%
     dplyr::filter(!grepl("package:", path)) %>%
     dplyr::pull(path)
 
@@ -312,7 +312,7 @@ attr(has_no_absolute_paths, "req_compilation") <- TRUE
 #' @export
 has_only_portable_paths <- function(path = ".", ...) {
   check_is_dir(path)
-  paths <- log_report(path) %>%
+  paths <- log_report(path_log(path)) %>%
     dplyr::filter(!grepl("package:", path)) %>%
     dplyr::pull(path)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,6 +14,7 @@ msg <- function(text) {
 }
 
 #' Utility function to check whether a provided path is a directory
+#' @param path Path you are wanting to check
 #' @importFrom rlang abort
 #' @export
 

--- a/man/check_is_dir.Rd
+++ b/man/check_is_dir.Rd
@@ -6,6 +6,9 @@
 \usage{
 check_is_dir(path)
 }
+\arguments{
+\item{path}{Path you are wanting to check}
+}
 \description{
 Utility function to check whether a provided path is a directory
 }

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -48,8 +48,8 @@ test_that("has functions work", {
   expect_false(has_tidy_scripts(test_dir)$state)
 
   # compilation
-  expect_true(has_no_absolute_paths(test_dir)$state)
-  expect_true(has_only_portable_paths(test_dir)$state)
+  expect_true(has_no_absolute_paths(dir)$state)
+  expect_true(has_only_portable_paths(dir)$state)
   expect_true(has_no_randomness(test_dir, seed_old)$state)
 
 })


### PR DESCRIPTION
Added `path_log` into the `log_report()` call in `has_no_absolute_paths()` and `has_no_portable_paths()`. This seems to have fixed the issue of not being able to open the log file within those functions.

Using dir = "tests/testthat/project_noob", check `expect_true(has_no_absolute_paths(dir))$state` now passes (when run line by line) from the `test-check.R` file, which it did not do previously. Using the same dir, `has_no_portable_paths` does not pass. I am not entirely clear on what constitutes a portable path, so it is possible that `has_no_portable_paths` needs to be passed a different directory in order to pass its check.

This is the current output when running `has_no_portable_paths(dir)`:

![screen shot 2019-02-01 at 6 30 49 pm](https://user-images.githubusercontent.com/33032410/52155232-b7d56c00-264f-11e9-8ac7-d43e56af39aa.png)
